### PR TITLE
Update Bitarray to Version 2.3.4

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bitarray" %}
-{% set version = "2.3.0" %}
+{% set version = "2.3.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 21f2e10420f9ae74d3bdfd3cb74947ddbe9fbc0b2e5662f2f039001954f1d8b6
+  sha256: f19c62425576d3d1821ed711b94d1a4e5ede8f05ca121e99b6d978ed49c7a765
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,12 +26,13 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:
     - bitarray
   requires:
+    - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,13 +26,12 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
     - bitarray
   requires:
-    - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,10 +11,8 @@ source:
 
 build:
   number: 1
-  {% if 'pypy' in python %}
   # https://github.com/ilanschnell/bitarray/issues/99
-  skip: true
-  {% endif %}
+  skip: true  # [python_impl == "pypy"]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,3 +1,3 @@
 import bitarray
 
-assert bitarray.test().wasSuccessful()
+assert bitarray.test(verbosity=2).wasSuccessful()


### PR DESCRIPTION
  `bitarray` version `2.3.4`
1. check the upstream
    https://github.com/ilanschnell/bitarray/tree/2.3.4

2. check the pinnings

https://github.com/ilanschnell/bitarray/blob/2.3.4/update_doc.py

https://github.com/ilanschnell/bitarray/blob/2.3.4/setup.py

3. check the changelogs
    https://github.com/ilanschnell/bitarray/blob/2.3.4/CHANGE_LOG
    
    Ther were only bug fixes and feature additions in the changelog. 

    There were no breaking changes mentioned

4. additional research
    https://github.com/conda-forge/bitarray-feedstock/issues

    There were no breaking changes mentioned in conda-forge

5. verify dev_url
    https://github.com/ilanschnell/bitarray

6. verify doc_url
    https://pypi.python.org/pypi/bitarray/0.8.1

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `bitarray` package version `2.3.4` the folowing
command was used:
`conda build bitarray-feedstock --test`
the test result was the following:
`All tests passed`

Based on the research findings and the test results we can conclude
that it is safe to update `bitarray` to version `2.3.4`
