### PR TITLE
bitarray 2.3.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,9 @@ source:
   sha256: 60285184cb02fdba5e1cc8605ac84e150a50f940e9383ab43564e5258d1f47bb
 
 build:
-  number: 1
-  {% if 'pypy' in python %}
+  number: 0
   # https://github.com/ilanschnell/bitarray/issues/99
-  skip: true
-  {% endif %}
+  skip: true  # [python_impl == "pypy"]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -38,7 +36,7 @@ test:
 
 about:
   home: https://github.com/ilanschnell/bitarray
-  license: PSF
+  license: PSF-2.0
   license_file: LICENSE
   license_family: PSF
   summary: efficient arrays of booleans -- C extension

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bitarray" %}
-{% set version = "2.3.0" %}
+{% set version = "2.3.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 21f2e10420f9ae74d3bdfd3cb74947ddbe9fbc0b2e5662f2f039001954f1d8b6
+  sha256: 60285184cb02fdba5e1cc8605ac84e150a50f940e9383ab43564e5258d1f47bb
 
 build:
   number: 1

--- a/recipe/run_test.py
+++ b/recipe/run_test.py
@@ -1,3 +1,3 @@
 import bitarray
 
-assert bitarray.test().wasSuccessful()
+assert bitarray.test(verbosity=2).wasSuccessful()


### PR DESCRIPTION
Update bitarray to 2.3.5

Version change: bump version number from 2.3.0 to 2.3.5
Bug Tracker: new open issues https://github.com/ilanschnell/bitarray/issues
Github changelog: https://github.com/ilanschnell/bitarray/blob/2.3.5/CHANGE_LOG
Upstream license:  License file:  https://github.com/ilanschnell/bitarray/blob/master/LICENSE
Upstream setup.py:  https://github.com/ilanschnell/bitarray/blob/2.3.5/setup.py

The package bitarray is mentioned inside the packages:
impyla |

Actions:
1. Reset build number to 0
2. Rewrite skip section
3. Fix license name

Result:
- all-succeeded
