### PR TITLE
bitarray 2.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bitarray" %}
-{% set version = "2.3.5" %}
+{% set version = "2.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 60285184cb02fdba5e1cc8605ac84e150a50f940e9383ab43564e5258d1f47bb
+  sha256: f1203e902d51df31917d77eeba9c3fe78d032873a2ad78c737e26420f0080e58
 
 build:
   number: 0


### PR DESCRIPTION
Update bitarray to 2.4.0

Version change: bump version number from 2.3.5 to 2.4.0
Bug Tracker: new open issues https://github.com/ilanschnell/bitarray/issues
Github changelog: https://github.com/ilanschnell/bitarray/blob/2.4.0/CHANGE_LOG
Upstream license: License file: https://github.com/ilanschnell/bitarray/blob/master/LICENSE
Upstream setup.py: https://github.com/ilanschnell/bitarray/blob/2.4.0/setup.py

The package bitarray is mentioned inside the packages:
impyla |

Actions:
1. 