### PR TITLE
bitarray from 2.4.1 to 2.5.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bitarray" %}
-{% set version = "2.4.1" %}
+{% set version = "2.5.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: faeca03f979e992cc76f7406af7eb9795cb111b8d8969c891a032bd7497c87da
+  sha256: 5abed04adcd2031f6e714993d95223bf9ae85354c640c270b2ed6f46b83573ba
 
 build:
   number: 0
-  # https://github.com/ilanschnell/bitarray/issues/99
-  skip: true  # [python_impl == "pypy"]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -44,7 +42,7 @@ about:
     Bitarray provides an object type which efficiently represents an array of
     booleans. Bitarrays are sequence types that behave very similarly
     to usual lists. All functionality is implemented in C.
-  doc_url: https://pypi.python.org/pypi/bitarray/0.8.1
+  doc_url: https://pypi.python.org/pypi/bitarray/{{ version }}
   doc_source_url: https://github.com/ilanschnell/bitarray/blob/master/README.rst
   dev_url: https://github.com/ilanschnell/bitarray
 


### PR DESCRIPTION
Update bitarray to 2.5.0

Version change: bump version number from 2.4.1 to 2.5.0
Bug Tracker: new open issues https://github.com/ilanschnell/bitarray/issues
Github changelog: https://github.com/ilanschnell/bitarray/blob/2.5.0/CHANGE_LOG
Github changes: https://github.com/ilanschnell/bitarray/compare/2.4.1...2.5.0
Upstream license: License file: https://github.com/ilanschnell/bitarray/blob/master/LICENSE
Upstream setup.py: https://github.com/ilanschnell/bitarray/blob/2.5.0/setup.py

The package bitarray is mentioned inside the packages:
impyla |

concourse: https://concourse.build.corp.continuum.io/teams/main/pipelines/cbousseau_bitarray
jira: https://anaconda.atlassian.net/browse/DSNC-4758

Actions:
- updated version
- updated doc version
- remove obsolete skip (fixed in 1.9.2)