### PR TITLE
bitarray-2.5.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bitarray" %}
-{% set version = "2.5.0" %}
+{% set version = "2.5.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 5abed04adcd2031f6e714993d95223bf9ae85354c640c270b2ed6f46b83573ba
+  sha256: 8d38f60751008099a659d5acfb35ef4150183effd5b2bfa6c10199270ddf4c9c
 
 build:
   number: 0


### PR DESCRIPTION
Changelog: (No apparent breaking changes) https://github.com/ilanschnell/bitarray/blob/64418777dd96804626a1090016c6e4072e776799/CHANGE_LOG#L10-L13

License: https://github.com/ilanschnell/bitarray/blob/master/LICENSE

Windows builds succeeded on Concourse ([pipeline](https://concourse.build.corp.continuum.io/teams/main/pipelines/pyim_bitarray_2.5.1)).